### PR TITLE
Added custom validity checking delegate method to PAPasscode

### DIFF
--- a/PAPasscode/PAPasscodeViewController.h
+++ b/PAPasscode/PAPasscodeViewController.h
@@ -26,7 +26,7 @@ typedef enum {
 - (void)PAPasscodeViewControllerDidEnterPasscode:(PAPasscodeViewController *)controller;
 - (void)PAPasscodeViewControllerDidSetPasscode:(PAPasscodeViewController *)controller;
 - (void)PAPasscodeViewController:(PAPasscodeViewController *)controller didFailToEnterPasscode:(NSInteger)attempts;
-
+- (BOOL)PAPasscodeViewController:(PAPasscodeViewController *)controller checkPasscodeValidityWithEntry:(NSString *)entry;
 @end
 
 @interface PAPasscodeViewController : UIViewController {

--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -72,6 +72,7 @@
     view.autoresizingMask = UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight;
 
     UINavigationBar *navigationBar = [[UINavigationBar alloc] initWithFrame:CGRectMake(0, 0, view.bounds.size.width, NAVBAR_HEIGHT)];
+	navigationBar.barStyle = UIBarStyleBlackOpaque;
     navigationBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     navigationBar.items = @[self.navigationItem];
     [view addSubview:navigationBar];

--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -217,7 +217,14 @@
 }
 
 #pragma mark - implementation helpers
-
+-(BOOL)passcodeIsValid:(NSString *)canidate{
+	if ([_delegate respondsToSelector:@selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)])
+	{
+		return [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:canidate];
+	} else {
+		return [canidate isEqualToString:_passcode];
+	}
+}
 - (void)handleCompleteField {
     NSString *text = passcodeTextField.text;
     switch (_action) {
@@ -240,12 +247,7 @@
             break;
             
         case PasscodeActionEnter:
-			if ((
-				[_delegate respondsToSelector:
-				 @selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
-			   [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:text] :
-			   [text isEqualToString:_passcode])
-				{
+			if ([self passcodeIsValid:text]){
                 [self resetFailedAttempts];
                 if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidEnterPasscode:)]) {
                     [_delegate PAPasscodeViewControllerDidEnterPasscode:self];

--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -229,7 +229,7 @@
                 if ((
 					 [_delegate respondsToSelector:
 						@selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
-					 [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:_passcode] :
+					 [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:text] :
 					 [text isEqualToString:_passcode]) 
 				{
                     if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidSetPasscode:)]) {

--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -226,11 +226,7 @@
                 messageLabel.text = @"";
                 [self showScreenForPhase:1 animated:YES];
             } else {
-                if ((
-					 [_delegate respondsToSelector:
-						@selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
-					 [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:text] :
-					 [text isEqualToString:_passcode]) 
+                if ([text isEqualToString:_passcode]) 
 				{
                     if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidSetPasscode:)]) {
                         [_delegate PAPasscodeViewControllerDidSetPasscode:self];
@@ -285,11 +281,7 @@
                 messageLabel.text = @"";
                 [self showScreenForPhase:2 animated:YES];
             } else {
-                if ((
-					 [_delegate respondsToSelector:
-					  @selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
-					[_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:text] :
-					[text isEqualToString:_passcode])
+                if ([text isEqualToString:_passcode])
 				{
                     if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidChangePasscode:)]) {
                         [_delegate PAPasscodeViewControllerDidChangePasscode:self];

--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -226,7 +226,12 @@
                 messageLabel.text = @"";
                 [self showScreenForPhase:1 animated:YES];
             } else {
-                if ([text isEqualToString:_passcode]) {
+                if ((
+					 [_delegate respondsToSelector:
+						@selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
+					 [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:_passcode] :
+					 [text isEqualToString:_passcode]) 
+				{
                     if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidSetPasscode:)]) {
                         [_delegate PAPasscodeViewControllerDidSetPasscode:self];
                     }

--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -243,7 +243,12 @@
             break;
             
         case PasscodeActionEnter:
-            if ([text isEqualToString:_passcode]) {
+			if ((
+				[_delegate respondsToSelector:
+				 @selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
+			   [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:text] :
+			   [text isEqualToString:_passcode])
+				{
                 [self resetFailedAttempts];
                 if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidEnterPasscode:)]) {
                     [_delegate PAPasscodeViewControllerDidEnterPasscode:self];
@@ -263,7 +268,12 @@
             
         case PasscodeActionChange:
             if (phase == 0) {
-                if ([text isEqualToString:_passcode]) {
+                if ((
+					[_delegate respondsToSelector:
+					 @selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
+				   [_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:text] :
+				   [text isEqualToString:_passcode])
+				{
                     [self resetFailedAttempts];
                     [self showScreenForPhase:1 animated:YES];
                 } else {
@@ -275,7 +285,12 @@
                 messageLabel.text = @"";
                 [self showScreenForPhase:2 animated:YES];
             } else {
-                if ([text isEqualToString:_passcode]) {
+                if ((
+					 [_delegate respondsToSelector:
+					  @selector(PAPasscodeViewController:checkPasscodeValidityWithEntry:)]) ?
+					[_delegate PAPasscodeViewController:self checkPasscodeValidityWithEntry:text] :
+					[text isEqualToString:_passcode])
+				{
                     if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidChangePasscode:)]) {
                         [_delegate PAPasscodeViewControllerDidChangePasscode:self];
                     }


### PR DESCRIPTION
So the general idea behind PAPasscodeViewController:checkPasscodeValidityWithEntry: is to enable the developer to implement a custom validity test for the entered passcode using whatever arbitrary means they see fit.

The reason why we implemented this delegate method is because for our solution, we store the passcode as a one-way hash that we obviously cannot unhash. Using this delegate method, we can hash the candidate entry and see if the hashes match.

Hope this helps!

(this is attempt #2, where the first attempt was closed by me because it was half-baked )
