### PR TITLE
Fixed a visual glitch dismissing keyboard

### DIFF
--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -256,6 +256,7 @@ static NSTimeInterval AnimationDuration = 0.3;
                 [self showScreenForPhase:1 animated:YES];
             } else {
                 if ([text isEqualToString:_passcode]) {
+                    [passcodeTextField resignFirstResponder];                    
                     if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidSetPasscode:)]) {
                         [_delegate PAPasscodeViewControllerDidSetPasscode:self];
                     }


### PR DESCRIPTION
Fixed a visual glitch that caused the keyboard to slowly dismiss
*after* the passcode view had already been dismissed.

## Before
![beforesmall](https://cloud.githubusercontent.com/assets/431529/9069846/a95ddcdc-3aa0-11e5-86f1-6f41fd811ca7.gif)


## After
![aftersmall](https://cloud.githubusercontent.com/assets/431529/9069851/ae8fcb34-3aa0-11e5-8ecd-0e58d3c563ea.gif)

