### PR TITLE
Visual glitch dismissing keyboard now fixed for all cases

### DIFF
--- a/PAPasscode/PAPasscodeViewController.m
+++ b/PAPasscode/PAPasscodeViewController.m
@@ -214,6 +214,10 @@ static NSTimeInterval AnimationDuration = 0.3;
     [self.view layoutIfNeeded];
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+	[passcodeTextField resignFirstResponder];
+}
+
 - (NSUInteger)supportedInterfaceOrientations {
     return UIInterfaceOrientationMaskPortrait|UIInterfaceOrientationMaskPortraitUpsideDown;
 }
@@ -256,7 +260,6 @@ static NSTimeInterval AnimationDuration = 0.3;
                 [self showScreenForPhase:1 animated:YES];
             } else {
                 if ([text isEqualToString:_passcode]) {
-                    [passcodeTextField resignFirstResponder];                    
                     if ([_delegate respondsToSelector:@selector(PAPasscodeViewControllerDidSetPasscode:)]) {
                         [_delegate PAPasscodeViewControllerDidSetPasscode:self];
                     }


### PR DESCRIPTION
The previous fix applied to when the user had successfully set up a new
password.

This fix should apply to all cases (including ‘Cancel’) because the
keyboard now resigns firstResponder anytime the view disappears.